### PR TITLE
Changed the name space for monopodsdk blmc_driver component tken from…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,31 +1,31 @@
 # ==============
 # Find Monopod SDK dependencies
 # ==============
-set(MONOPODSDK_COMPONENTS MonopodSDK BlmcDrivers MonopodDrivers)
+set(MONOPODSDK_COMPONENTS monopod_sdk blmc_drivers monopod_drivers)
 
 set(MONOPODSDK_PRIVATE_DEPENDENCIES pybind11 Eigen3 mpi_cmake_modules
     real_time_tools signal_handler shared_memory time_series)
 
-# add_subdirectory(blmc_drivers)
+add_subdirectory(blmc_drivers)
 # add_subdirectory(monopod_drivers)
 # add_subdirectory(monopod_sdk)
 
 # Dummy meta target for the top-level EXPORT
-add_library(MonopodSDK INTERFACE)
+add_library(monopod_sdk INTERFACE)
 
 # =================================================================
 # Install is not something supported now. need to fix build
 # dependencies first.
 # =================================================================
 
-# install(TARGETS MonopodSDK EXPORT MonopodSDKExport)
-#
-# install_basic_package_files(MonopodSDK
-#     VERSION ${PROJECT_VERSION}
-#     COMPATIBILITY AnyNewerVersion
-#     EXPORT MonopodSDKExport
-#     DEPENDENCIES ${MONOPODSDK_COMPONENTS}
-#     PRIVATE_DEPENDENCIES ${MONOPODSDK_PRIVATE_DEPENDENCIES}
-#     NAMESPACE MonopodSDK::
-#     NO_CHECK_REQUIRED_COMPONENTS_MACRO
-#     INSTALL_DESTINATION ${MONOPODSDK_INSTALL_LIBDIR}/cmake/MonopodSDK)
+install(TARGETS monopod_sdk EXPORT monopod_sdkExport)
+
+install_basic_package_files(monopod_sdk
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+    EXPORT monopod_sdkExport
+    DEPENDENCIES ${MONOPODSDK_COMPONENTS}
+    PRIVATE_DEPENDENCIES ${MONOPODSDK_PRIVATE_DEPENDENCIES}
+    NAMESPACE monopod_sdk::
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    INSTALL_DESTINATION ${MONOPODSDK_INSTALL_LIBDIR}/cmake/monopod_sdk)

--- a/src/blmc_drivers/CMakeLists.txt
+++ b/src/blmc_drivers/CMakeLists.txt
@@ -1,48 +1,100 @@
 # =========
-# Monopod Drivers
+# Blmc Drivers
 # =========
 
+# Usual dependencies.
+find_package(mpi_cmake_modules REQUIRED)
+find_package(real_time_tools REQUIRED)
+find_package(time_series REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(rt REQUIRED)
+find_package(Threads REQUIRED)
+# Check for xenomai as these drivers are xenomai compatible.
+find_package(Xenomai QUIET)
+
+if(Xenomai_FOUND)
+  add_definitions(${Xenomai_DEFINITIONS})
+endif()
+
 set(BLMC_DRIVERS_PUBLIC_HDRS
-# include/monopod_sdk/easylogging++.h
+    include/monopod_sdk/blmc_drivers/devices/analog_sensor.hpp
+    include/monopod_sdk/blmc_drivers/devices/can_bus.hpp
+    include/monopod_sdk/blmc_drivers/devices/device_interface.hpp
+    include/monopod_sdk/blmc_drivers/devices/leg.hpp
+    include/monopod_sdk/blmc_drivers/devices/motor_board.hpp
+    include/monopod_sdk/blmc_drivers/devices/motor.hpp
+    include/monopod_sdk/blmc_drivers/utils/polynome.hpp
+    include/monopod_sdk/blmc_drivers/serial_reader.hpp
+    include/monopod_sdk/blmc_drivers/blmc_joint_module.hpp
 )
 
-add_library(BlmcDrivers
+add_library(blmc_drivers
     ${BLMC_DRIVERS_PUBLIC_HDRS}
-    # src/easylogging++.cc
+     src/analog_sensors.cpp
+     src/blmc_joint_module.cpp
+     src/can_bus.cpp
+     src/motor_board.cpp
+     src/motor.cpp
+     src/serial_reader.cpp
+     src/utils/polynome.cpp
   )
 
-add_library(BlmcDrivers::BlmcDrivers ALIAS BlmcDrivers)
+if(Xenomai_FOUND)
+  target_include_directories(${PROJECT_NAME} PUBLIC ${Xenomai_INCLUDE_DIR})
+endif()
 
-target_include_directories(BlmcDrivers PUBLIC
+# Link the catkin dependencies.
+add_dependencies(blmc_drivers rt::rt)
+target_link_libraries(blmc_drivers real_time_tools::real_time_tools)
+target_link_libraries(blmc_drivers time_series::time_series)
+target_link_libraries(blmc_drivers Eigen3::Eigen)
+target_link_libraries(blmc_drivers Threads::Threads)
+
+# If on xenomai we need to link to the real time os librairies.
+if(Xenomai_FOUND)
+  target_link_libraries(blmc_drivers ${Xenomai_LIBRARY_XENOMAI}
+                        ${Xenomai_LIBRARY_NATIVE} ${Xenomai_LIBRARY_RTDM})
+endif()
+
+add_library(blmc_drivers::blmc_drivers ALIAS blmc_drivers)
+
+target_include_directories(blmc_drivers PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${MONOPODSDK_INSTALL_INCLUDEDIR}>)
 
-set_target_properties(BlmcDrivers PROPERTIES
+set_target_properties(blmc_drivers PROPERTIES
 PUBLIC_HEADER "${BLMC_DRIVERS_PUBLIC_HDRS}")
 
 
-# =================================================================
-# Install is not something supported now. need to fix build
-# dependencies first.
-# =================================================================
+#
+# Manage exectuables
+#
 
-# install(
-#     TARGETS
-#     MonopodSDK
-#     EXPORT MonopodSDKExport
-#     LIBRARY DESTINATION ${MONOPODSDK_INSTALL_LIBDIR}
-#     ARCHIVE DESTINATION ${MONOPODSDK_INSTALL_LIBDIR}
-#     RUNTIME DESTINATION ${MONOPODSDK_INSTALL_BINDIR}
-#     PUBLIC_HEADER DESTINATION ${MONOPODSDK_INSTALL_INCLUDEDIR}/monopodSDK)
-#
-#
-# install_basic_package_files(MonopodSDK
-#     COMPONENT SDK
-#     VERSION ${PROJECT_VERSION}
-#     COMPATIBILITY AnyNewerVersion
-#     EXPORT MonopodSDKExport
-#     NAMESPACE MonopodSDK::
-#     NO_CHECK_REQUIRED_COMPONENTS_MACRO
-#     INSTALL_DESTINATION
-#     ${MONOPODSDK_INSTALL_LIBDIR}/cmake/MonopodSDK
-# )
+add_executable(can_encoder_index_test
+    src/programs/can_encoder_index_test.cpp
+)
+target_link_libraries(can_encoder_index_test
+    blmc_drivers
+)
+
+
+install(
+    TARGETS
+    blmc_drivers can_encoder_index_test
+    EXPORT blmc_driversExport
+    LIBRARY DESTINATION ${MONOPODSDK_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${MONOPODSDK_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${MONOPODSDK_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${MONOPODSDK_INSTALL_INCLUDEDIR}/monopod_sdk/blmc_drivers)
+
+
+install_basic_package_files(blmc_drivers
+    COMPONENT blmc_drivers
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+    EXPORT blmc_driversExport
+    NAMESPACE blmc_drivers::
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    INSTALL_DESTINATION
+    ${MONOPODSDK_INSTALL_LIBDIR}/cmake/monopod_sdk/blmc_drivers
+)

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/blmc_joint_module.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/blmc_joint_module.hpp
@@ -16,8 +16,8 @@
 
 #include <Eigen/Eigen>
 
-#include "blmc_drivers/devices/motor.hpp"
-#include "blmc_drivers/utils/polynome.hpp"
+#include "monopod_sdk/blmc_drivers/devices/motor.hpp"
+#include "monopod_sdk/blmc_drivers/utils/polynome.hpp"
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/analog_sensor.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/analog_sensor.hpp
@@ -14,8 +14,8 @@
 #include <time_series/time_series.hpp>
 #include "real_time_tools/timer.hpp"
 
-#include "blmc_drivers/devices/device_interface.hpp"
-#include "blmc_drivers/devices/motor_board.hpp"
+#include "monopod_sdk/blmc_drivers/devices/device_interface.hpp"
+#include "monopod_sdk/blmc_drivers/devices/motor_board.hpp"
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/can_bus.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/can_bus.hpp
@@ -19,8 +19,8 @@
 
 #include <time_series/time_series.hpp>
 
-#include "blmc_drivers/devices/device_interface.hpp"
-#include "blmc_drivers/utils/os_interface.hpp"
+#include "monopod_sdk/blmc_drivers/devices/device_interface.hpp"
+#include "monopod_sdk/blmc_drivers/utils/os_interface.hpp"
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/leg.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/leg.hpp
@@ -14,8 +14,8 @@
 
 #include <time_series/time_series.hpp>
 
-#include <blmc_drivers/devices/device_interface.hpp>
-#include <blmc_drivers/devices/motor.hpp>
+#include <monopod_sdk/blmc_drivers/devices/device_interface.hpp>
+#include <monopod_sdk/blmc_drivers/devices/motor.hpp>
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/motor.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/motor.hpp
@@ -14,8 +14,8 @@
 #include <real_time_tools/timer.hpp>
 #include <time_series/time_series.hpp>
 
-#include "blmc_drivers/devices/device_interface.hpp"
-#include "blmc_drivers/devices/motor_board.hpp"
+#include "monopod_sdk/blmc_drivers/devices/device_interface.hpp"
+#include "monopod_sdk/blmc_drivers/devices/motor_board.hpp"
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/motor_board.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/devices/motor_board.hpp
@@ -15,9 +15,9 @@
 #include <real_time_tools/timer.hpp>
 #include <time_series/time_series.hpp>
 
-#include "blmc_drivers/devices/can_bus.hpp"
-#include "blmc_drivers/devices/device_interface.hpp"
-#include "blmc_drivers/utils/os_interface.hpp"
+#include "monopod_sdk/blmc_drivers/devices/can_bus.hpp"
+#include "monopod_sdk/blmc_drivers/devices/device_interface.hpp"
+#include "monopod_sdk/blmc_drivers/utils/os_interface.hpp"
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/include/monopod_sdk/blmc_drivers/utils/polynome.hpp
+++ b/src/blmc_drivers/include/monopod_sdk/blmc_drivers/utils/polynome.hpp
@@ -161,4 +161,4 @@ protected:
 
 }  // namespace blmc_drivers
 
-#include "blmc_drivers/utils/polynome.hxx"
+#include "monopod_sdk/blmc_drivers/utils/polynome.hxx"

--- a/src/blmc_drivers/src/analog_sensors.cpp
+++ b/src/blmc_drivers/src/analog_sensors.cpp
@@ -10,7 +10,7 @@
  *
  */
 
-#include <blmc_drivers/devices/analog_sensor.hpp>
+#include <monopod_sdk/blmc_drivers/devices/analog_sensor.hpp>
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/src/blmc_joint_module.cpp
+++ b/src/blmc_drivers/src/blmc_joint_module.cpp
@@ -8,7 +8,7 @@
  * @date 2019-07-11
  */
 
-#include "blmc_drivers/blmc_joint_module.hpp"
+#include "monopod_sdk/blmc_drivers/blmc_joint_module.hpp"
 #include <cmath>
 #include "real_time_tools/iostream.hpp"
 #include "real_time_tools/spinner.hpp"

--- a/src/blmc_drivers/src/can_bus.cpp
+++ b/src/blmc_drivers/src/can_bus.cpp
@@ -13,7 +13,7 @@
 
 #include <sstream>
 
-#include <blmc_drivers/devices/can_bus.hpp>
+#include <monopod_sdk/blmc_drivers/devices/can_bus.hpp>
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/src/motor.cpp
+++ b/src/blmc_drivers/src/motor.cpp
@@ -10,7 +10,7 @@
  *
  */
 
-#include <blmc_drivers/devices/motor.hpp>
+#include <monopod_sdk/blmc_drivers/devices/motor.hpp>
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/src/motor_board.cpp
+++ b/src/blmc_drivers/src/motor_board.cpp
@@ -4,7 +4,7 @@
  * @author Manuel Wuthrich (manuel.wuthrich@gmail.com)
  * @author Maximilien Naveau (maximilien.naveau@gmail.com)
  * @brief This file implements the classes from
- * "blmc_drivers/devices/motor_board.hpp"
+ * "monopod_sdk/blmc_drivers/devices/motor_board.hpp"
  * @version 0.1
  * @date 2018-11-26
  *
@@ -12,7 +12,7 @@
  *
  */
 
-#include <blmc_drivers/devices/motor_board.hpp>
+#include <monopod_sdk/blmc_drivers/devices/motor_board.hpp>
 
 namespace blmc_drivers
 {

--- a/src/blmc_drivers/src/programs/can_encoder_index_test.cpp
+++ b/src/blmc_drivers/src/programs/can_encoder_index_test.cpp
@@ -16,7 +16,7 @@
 #include <real_time_tools/spinner.hpp>
 #include <real_time_tools/thread.hpp>
 
-#include <blmc_drivers/blmc_joint_module.hpp>
+#include <monopod_sdk/blmc_drivers/blmc_joint_module.hpp>
 
 using namespace blmc_drivers;
 

--- a/src/blmc_drivers/src/serial_reader.cpp
+++ b/src/blmc_drivers/src/serial_reader.cpp
@@ -9,7 +9,7 @@
  *
  */
 
-#include "blmc_drivers/serial_reader.hpp"
+#include "monopod_sdk/blmc_drivers/serial_reader.hpp"
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>

--- a/src/blmc_drivers/src/utils/polynome.cpp
+++ b/src/blmc_drivers/src/utils/polynome.cpp
@@ -13,7 +13,7 @@
  * for further enhancement.
  */
 
-#include <blmc_drivers/utils/polynome.hpp>
+#include <monopod_sdk/blmc_drivers/utils/polynome.hpp>
 #include <iostream>
 
 namespace blmc_drivers


### PR DESCRIPTION
… ORDI. This allows the blmc drivers to now be a component of the monopod_sdk. as we want.